### PR TITLE
upgrade org.json version for CVE-2022-45688

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20220924</version>
+      <version>20230227</version>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
fix the issue of https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45688 caused by org.json